### PR TITLE
Update cisco_ios_show_power_inline.textfsm

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_power_inline.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_power_inline.textfsm
@@ -21,4 +21,4 @@ Interfaces
   ^\s+\(Watts\)
   ^-+
   ^\s*$$
-  ^. -> Error
+  ^.


### PR DESCRIPTION
There is a blank line between module output, so I'm not sure why that would be an Error and not simply ingested.  Tested on 16.12.8 and 17.9.5.